### PR TITLE
Fix to work with Rails 5.x

### DIFF
--- a/lib/redmine_default_members/patches/projects_controller_patch.rb
+++ b/lib/redmine_default_members/patches/projects_controller_patch.rb
@@ -9,7 +9,8 @@ module RedmineDefaultMembers
         base.class_eval do
           unloadable
 
-          alias_method_chain :create, :default_members
+          alias_method :create_without_default_members, :create
+          alias_method :create, :create_with_default_members
         end
       end
 


### PR DESCRIPTION
All is said in the title
alias_method_chain deprecated in rails 5.x, replaced by alias_method