### PR TITLE
Fix: Redmine6.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ group :development, :test do
   gem 'rspec', '~> 3.0.0'
   gem 'rspec-rails', '~> 3.0.1'
 
-  gem 'shoulda', '~> 3.5.0'
-  gem 'shoulda-matchers', '~> 2.7.0'
+  gem 'shoulda', '~> 4.0'
+  gem 'shoulda-matchers', '~> 4.5'
   gem 'shoulda-context'
 
   gem 'factory_girl'

--- a/init.rb
+++ b/init.rb
@@ -13,10 +13,12 @@ Redmine::Plugin.register :redmine_default_members do
   author_url 'mailto:nrodriguez@jbox-web.com'
 
   settings({
-    :partial => 'settings/redmine_default_members_settings',
-    :template => {
-      :group => 'Superviseur',
-      :roles => []
-    }
+    :default => {
+      'template' => {
+        'group' => 'Superviseur',
+        'roles' => []
+      }
+    },
+    :partial => 'settings/redmine_default_members_settings'
   })
 end

--- a/lib/redmine_default_members/patches/projects_controller_patch.rb
+++ b/lib/redmine_default_members/patches/projects_controller_patch.rb
@@ -36,12 +36,14 @@ module RedmineDefaultMembers
           end
 
           def create_default_members
-            Setting.plugin_redmine_default_members.each do |key, default_members|
-              next if key == 'template'
-              next if default_members[:roles].empty?
-              group = Group.find_by_lastname(default_members[:group])
-              roles = Role.where(id: default_members[:roles])
-              Member.create(principal: group, role_ids: roles.map(&:id), project: @project)
+            if Setting.plugin_redmine_default_members.present?
+              Setting.plugin_redmine_default_members.each do |key, default_members|
+                next if key == 'template'
+                next if default_members[:roles].empty?
+                group = Group.find_by_lastname(default_members[:group])
+                roles = Role.where(id: default_members[:roles])
+                Member.create(principal: group, role_ids: roles.map(&:id), project: @project)
+              end
             end
           end
 


### PR DESCRIPTION
Creating a Project failed with a Nil Error, if the plugin settings had not been touched. 

So i added a Nil check to the `create_default_members` function. And adapted the settings in init.rb to contain the `default` key, which makes Redmine 6.0 create the setting (redundant  but in a good way I'd say).

